### PR TITLE
Issue #SB-11432: Default version number will be used for ASSESS event if present in the data

### DIFF
--- a/js/core/telemetryV3Interface.js
+++ b/js/core/telemetryV3Interface.js
@@ -127,7 +127,13 @@ var Telemetry = (function() {
      */
     this.telemetry.assess = function(data, options) {
         instance.updateValues(options);
-        instance._dispatch(instance.getEvent('ASSESS', data));
+        assessEvent = instance.getEvent('ASSESS', data);
+        // This code will replace the default version, only if it has one. 
+        if (data.item && data.item.eventVer) {
+            assessEvent.ver = data.item.eventVer;
+            delete assessEvent.edata.item.eventVer;
+        }     
+        instance._dispatch(assessEvent);
     }
 
     /**


### PR DESCRIPTION
- [Issue Link](https://project-sunbird.atlassian.net/browse/SB-11432)
- Default version number will be used for telemetry asses event, if it has one.
