### PR TITLE
Telemetry method update to support Angular 9

### DIFF
--- a/js/core/telemetryV3Interface.js
+++ b/js/core/telemetryV3Interface.js
@@ -23,7 +23,7 @@ var libraryDispatcher = {
 };
 
 
-var Telemetry = (function() {
+var Telemetry = (() => {
     this.telemetry = function() {};
     var instance = function() {};
     var telemetryInstance = this;

--- a/js/dist/index.js
+++ b/js/dist/index.js
@@ -1825,7 +1825,7 @@ var libraryDispatcher = {
 };
 
 
-var Telemetry = (function() {
+var Telemetry = (() => {
     this.telemetry = function() {};
     var instance = function() {};
     var telemetryInstance = this;


### PR DESCRIPTION
Updated Telemetry method to arrow syntax. In Angular 9 'this' was undefined as it was looking for it in local scope. By converting to arrow function it found the definition globally.