### PR TITLE
fix: await async custom dispatcher during telemetry sync

### DIFF
--- a/src/core/TelemetryConfig.ts
+++ b/src/core/TelemetryConfig.ts
@@ -12,7 +12,7 @@ export interface TelemetryConfig {
   endpoint?: string;
   tags?: string[];
   cdata?: Array<{ type: string; id: string }>;
-  dispatcher?: { dispatch: (event: any) => void };
+  dispatcher?: { dispatch: (event: any) => void | Promise<unknown> };
   enableValidation?: boolean;
   timeDiff?: number;
   runningEnv?: string;

--- a/src/core/TelemetrySyncManager.ts
+++ b/src/core/TelemetrySyncManager.ts
@@ -67,7 +67,7 @@ export class TelemetrySyncManager {
 
     try {
       if (this._config.dispatcher && typeof this._config.dispatcher.dispatch === 'function') {
-        this._config.dispatcher.dispatch(telemetryObj);
+        await this._config.dispatcher.dispatch(telemetryObj);
         // Reset retry attempts on success
         this._retryAttempts = 0;
       } else {
@@ -132,7 +132,7 @@ export class TelemetrySyncManager {
 
     try {
       if (this._config.dispatcher && typeof this._config.dispatcher.dispatch === 'function') {
-        this._config.dispatcher.dispatch(telemetryObj);
+        await this._config.dispatcher.dispatch(telemetryObj);
         console.log('Retry successful');
       } else {
         await Dispatcher.dispatch(fullPath, telemetryObj, headers);

--- a/test/TelemetrySyncManager.test.ts
+++ b/test/TelemetrySyncManager.test.ts
@@ -162,6 +162,40 @@ describe('TelemetrySyncManager', () => {
         expect(Dispatcher.dispatch).not.toHaveBeenCalled();
     });
 
+    it('should retry async custom dispatcher failures without dropping failed batch', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        const customDispatch = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('initial async dispatcher failed'))
+            .mockRejectedValueOnce(new Error('retry async dispatcher failed'));
+
+        testConfig.dispatcher = { dispatch: customDispatch };
+        syncManager.updateConfig(testConfig);
+
+        syncManager.sendTelemetry({
+            eid: 'END',
+            edata: { type: 'app' },
+            context: {},
+        });
+
+        await flushPromises();
+
+        expect(customDispatch).toHaveBeenCalledTimes(1);
+        expect((syncManager as any)._failedBatch).toHaveLength(1);
+        expect((syncManager as any)._failedBatch[0].events[0].eid).toBe('END');
+
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(customDispatch).toHaveBeenCalledTimes(2);
+        expect((syncManager as any)._failedBatch).toHaveLength(1);
+        expect((syncManager as any)._failedBatch[0].events[0].eid).toBe('END');
+
+        consoleErrorSpy.mockRestore();
+        consoleLogSpy.mockRestore();
+    });
+
     it('should construct correct URL from host and endpoint', async () => {
         const mockDispatch = vi.mocked(Dispatcher.dispatch);
         mockDispatch.mockResolvedValue({});


### PR DESCRIPTION
## Summary

Fixes #62.

This PR allows custom telemetry dispatchers to return a Promise and ensures async dispatcher failures are handled by the existing retry flow.

## Problem

The SDK supports custom dispatchers, but `TelemetrySyncManager` called `dispatcher.dispatch(...)` without `await`. If a custom dispatcher returned a rejected Promise, the surrounding `try/catch` would not catch the error, so failed batches could bypass retry handling.

## Changes

- Updated the custom dispatcher type to allow `void | Promise<unknown>`.
- Awaited custom dispatcher calls in normal sync and retry sync paths.
- Added a regression test for rejected async custom dispatchers.

## Validation

- `npm test` — 36 tests passed
- `npm run build` — CJS, ESM, IIFE, and DTS builds passed
- `npm run lint` — completed with no lint errors