### PR TITLE
fix: normalize invalid telemetry batch size

### DIFF
--- a/src/core/TelemetrySyncManager.ts
+++ b/src/core/TelemetrySyncManager.ts
@@ -21,20 +21,32 @@ export class TelemetrySyncManager {
     this._config = config;
   }
 
+  private _getBatchSize(): number {
+    const defaultBatchSize = 20;
+    const maxBatchSize = 1000;
+    const batchSize = Number(this._config.batchsize);
+
+    if (!Number.isFinite(batchSize) || batchSize < 1) {
+      return defaultBatchSize;
+    }
+
+    return Math.min(Math.floor(batchSize), maxBatchSize);
+  }
+
   public sendTelemetry(event: any) {
     const telemetryEvent = event.detail || event;
     this._teleData.push({ ...telemetryEvent });
 
     if (
       (telemetryEvent.eid && telemetryEvent.eid.toUpperCase() === 'END') ||
-      this._teleData.length >= (this._config.batchsize || 20)
+      this._teleData.length >= this._getBatchSize()
     ) {
       this.syncEvents();
     }
   }
 
   public async syncEvents() {
-    const batchSize = this._config.batchsize || 20;
+    const batchSize = this._getBatchSize();
 
     if (!this._teleData.length) {
       return;

--- a/test/TelemetrySyncManager.test.ts
+++ b/test/TelemetrySyncManager.test.ts
@@ -66,6 +66,26 @@ describe('TelemetrySyncManager', () => {
         expect(callArgs[1].events).toHaveLength(5);
     });
 
+    it('should normalize invalid negative batchsize before syncing events', async () => {
+        const mockDispatch = vi.mocked(Dispatcher.dispatch);
+        mockDispatch.mockResolvedValue({});
+
+        testConfig.batchsize = -1;
+        syncManager.updateConfig(testConfig);
+
+        syncManager.sendTelemetry({
+            eid: 'END',
+            edata: { type: 'app' },
+            context: {},
+        });
+
+        await flushPromises();
+
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+        expect(mockDispatch.mock.calls[0][1].events).toHaveLength(1);
+        expect(mockDispatch.mock.calls[0][1].events[0].eid).toBe('END');
+    });
+
     it('should sync events on END event regardless of batch size', async () => {
         const mockDispatch = vi.mocked(Dispatcher.dispatch);
         mockDispatch.mockResolvedValue({});


### PR DESCRIPTION
## Summary

Fixes #64

This PR normalizes invalid telemetry `batchsize` values before sync logic uses them.

## Problem

`batchsize` is a public configuration option. While valid values work as expected, invalid runtime values such as negative numbers can be used directly by `TelemetrySyncManager`.

For example, `batchsize: -1` is truthy in JavaScript, so it does not fall back to the default value when used with `|| 20`. This can cause the sync manager to create an empty or incorrect telemetry batch instead of syncing the queued event.

## Changes

- Added normalization for the effective telemetry batch size.
- Falls back to the default batch size for invalid values.
- Floors decimal values.
- Caps values above the maximum batch size.
- Added regression coverage for invalid negative batch size.

## Validation

- `npm test`
- `npm run build`
- `npm run lint`